### PR TITLE
pass compact=false on setMetadata

### DIFF
--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -17,11 +17,11 @@ export interface Client {
 
     info(section?: string): Promise<(string | string[])[]>
 
-    query<T>(graph: string, query: RedisCommandArgument,options?: QueryOptions): Promise<any>
+    query<T>(graph: string, query: RedisCommandArgument,options?: QueryOptions, compact?: boolean): Promise<any>
 
     profile<T>(graph: string, query: RedisCommandArgument): Promise<any>
 
-    roQuery<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions): Promise<any>
+    roQuery<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions, compact?: boolean): Promise<any>
 
     copy<T>(srcGraph: string, destGraph: string): Promise<any>
 

--- a/src/clients/cluster.ts
+++ b/src/clients/cluster.ts
@@ -43,11 +43,11 @@ export class Cluster implements Client {
             .connect();
     }
 
-    async query<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions) {
-        return this.#client.falkordb.query(graph, query, options, true)
+    async query<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions, compact=true) {
+        return this.#client.falkordb.query(graph, query, options, compact)
     }
-    async roQuery<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions) {
-        return this.#client.falkordb.roQuery(graph, query, options, true)
+    async roQuery<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions, compact=true) {
+        return this.#client.falkordb.roQuery(graph, query, options, compact)
     }
 
     async delete(graph: string) {

--- a/src/clients/single.ts
+++ b/src/clients/single.ts
@@ -21,7 +21,7 @@ export class Single implements Client {
 		return Promise.resolve();
 	}
 
-    async query<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions) {
+    async query<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions, compact=true) {
 
         const reply = this.#usePool ?
             await this.client.executeIsolated(async isolatedClient => {
@@ -29,7 +29,7 @@ export class Single implements Client {
                     graph,
                     query,
                     options,
-                    true
+                    compact
                 )
             })
             :
@@ -37,20 +37,20 @@ export class Single implements Client {
                 graph,
                 query,
                 options,
-                true
+                compact
             );
 
         return reply;
     }
 	
-    async roQuery<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions) {
+    async roQuery<T>(graph: string, query: RedisCommandArgument, options?: QueryOptions, compact=true) {
         const reply = this.#usePool ?
 			await this.client.executeIsolated(async isolatedClient => {
 				return isolatedClient.falkordb.roQuery(
 					graph,
 					query,
 					options,
-					true
+					compact
 				)
 			})
 			:
@@ -58,7 +58,7 @@ export class Single implements Client {
 				graph,
 				query,
 				options,
-				true
+				compact
 			);
 
 		return reply;

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -232,9 +232,9 @@ export default class Graph {
 	// DO NOT use directly, use #updateMetadata instead
 	async #setMetadata(): Promise<GraphMetadata> {
 		const [labels, relationshipTypes, propertyKeys] = await Promise.all([
-			this.#client.roQuery(this.#name, 'CALL db.labels()'),
-			this.#client.roQuery(this.#name, 'CALL db.relationshipTypes()'),
-			this.#client.roQuery(this.#name, 'CALL db.propertyKeys()')
+			this.#client.roQuery(this.#name, 'CALL db.labels()', undefined, false),
+			this.#client.roQuery(this.#name, 'CALL db.relationshipTypes()', undefined, false),
+			this.#client.roQuery(this.#name, 'CALL db.propertyKeys()', undefined, false)
 		]);
 
 		this.#metadata = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional `compact` parameter for `query` and `roQuery` methods across various client classes, allowing users to control the output format of queries.
  
- **Bug Fixes**
  - Adjusted method calls to improve query execution context and handling of results in the `Graph` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->