### PR TITLE
Make sure sentinel is closed on quit()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falkordb",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falkordb",
-      "version": "6.2.3",
+      "version": "6.2.4",
       "license": "MIT",
       "workspaces": [
         "./packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkordb",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "A FalkorDB javascript library",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/src/clients/sentinel.ts
+++ b/src/clients/sentinel.ts
@@ -19,7 +19,7 @@ function extractDetails(masters: Array<Array<string>>) {
 
 export class Sentinel extends Single {
 
-    private sentinelClient: SingleGraphConnection | undefined;
+    private sentinelClient!: SingleGraphConnection;
 
     init(falkordb: FalkorDB): Promise<void> {
         const redisOption = (this.client.options ?? {}) as TypedRedisClientOptions;

--- a/src/clients/sentinel.ts
+++ b/src/clients/sentinel.ts
@@ -85,11 +85,14 @@ export class Sentinel extends Single {
     }
 
     async quit() {
-        await super.quit();
+        const promises = [
+            super.quit()
+        ];
         if (this.sentinelClient) {
             const reply = this.sentinelClient.quit();
-            return reply.then(() => {})
+            promises.push(reply.then(() => {}))
         }
+        return Promise.all(promises).then(() => {});
     }
 }
 

--- a/src/clients/sentinel.ts
+++ b/src/clients/sentinel.ts
@@ -19,7 +19,7 @@ function extractDetails(masters: Array<Array<string>>) {
 
 export class Sentinel extends Single {
 
-    private sentinelClient: SingleGraphConnection;
+    private sentinelClient: SingleGraphConnection | undefined;
 
     init(falkordb: FalkorDB): Promise<void> {
         const redisOption = (this.client.options ?? {}) as TypedRedisClientOptions;

--- a/src/clients/sentinel.ts
+++ b/src/clients/sentinel.ts
@@ -52,7 +52,7 @@ export class Sentinel extends Single {
         };
         const realClient = createClient<{ falkordb: typeof commands }, RedisFunctions, RedisScripts>(serverOptions)
 
-        // Save sentinel client to quite on quit()
+        // Save sentinel client to quit on quit()
         this.sentinelClient = client;
 
         // Set original client as sentinel and server client as client


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `quit` method to manage the lifecycle of the sentinel client connection.
- **Improvements**
	- Enhanced connection management for the sentinel client, ensuring better handling during quit operations.
- **Chores**
	- Updated version number from 6.2.3 to 6.2.4 in the package.json file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->