### PR TITLE
fix trigger npm publish

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -130,7 +130,8 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   publish-npm:
-    if: ${{ github.event.workflow_run.event == 'release' }}
+    # Run only when a new release is created
+    if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow conditions to ensure publishing to npm only occurs when a new release is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->