### PR TITLE
Guard error emit with listenerCount to fix connect() hang

### DIFF
--- a/src/clients/cluster.ts
+++ b/src/clients/cluster.ts
@@ -55,7 +55,9 @@ export class Cluster implements Client {
 
   async init(falkordb: FalkorDB) {
     await this.#client
-      .on("error", (err) => falkordb.emit("error", err)) // Forward errors
+      .on("error", (err) => {
+        if (falkordb.listenerCount("error") > 0) falkordb.emit("error", err);
+      })
       .connect();
   }
 

--- a/src/clients/sentinel.ts
+++ b/src/clients/sentinel.ts
@@ -84,7 +84,9 @@ export class Sentinel extends Single {
           console.debug("Error on server reconnect", e);
 
           // Forward errors if reconnection fails
-          falkordb.emit("error", err);
+          if (falkordb.listenerCount("error") > 0) {
+            falkordb.emit("error", err);
+          }
         }
       })
       .connect();

--- a/src/falkordb.ts
+++ b/src/falkordb.ts
@@ -136,7 +136,9 @@ export default class FalkorDB extends EventEmitter {
         // Create initial redis single client
         const redisClient = createClient<{ falkordb: typeof commands }, RedisFunctions, RedisScripts, 2, {}>(redisOption)
         await redisClient
-            .on('error', err => falkordb.emit('error', err)) // Forward errors
+            .on('error', err => {
+                if (falkordb.listenerCount('error') > 0) falkordb.emit('error', err);
+            })
             .connect();
 
         // Create FalkorDB client wrapper


### PR DESCRIPTION
## Summary
- Guard `falkordb.emit('error', err)` with `listenerCount` check in all three connection paths (single, cluster, sentinel)
- During `connect()`, the `FalkorDB` instance has no error listeners yet. If the redis client emits an error (e.g. `CLIENT SETINFO` not supported), calling `emit('error')` on an EventEmitter with no listeners throws an exception, which corrupts the redis client's internal state and causes `connect()` to hang indefinitely
- With this fix, errors during connection are silently handled, keeping the redis client healthy. After `connect()` returns and the user adds their error listener, errors are forwarded normally

## Test plan
- [ ] CI passes on both Node 20.x and 22.x (the UDF tests were consistently hanging due to this bug)
- [ ] Existing error forwarding behavior is unchanged for users who register error listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized error handling across cluster, sentinel, and client connections to emit errors only when listeners are present, improving efficiency and preventing unnecessary error event propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->