### PR TITLE
feat: add stubs command for listing offloaded graphs and implement related functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ db.close()
 
 To learn more about Cypher query language check: https://docs.falkordb.com/cypher/
 
+#### `.stubs()`
+
+Lists the graphs that are currently offloaded to disk ("stubs"). `db.list()` already includes
+offloaded graphs, so `stubs()` is how you tell which of the listed graphs are not loaded in memory.
+
+`GRAPH.STUBS` is provided by the FalkorDB Enterprise graph-offloading module, so on deployments
+without that module the call rejects with an "unknown command" error — treat that as
+"offloading is not supported here".
+
+```typescript
+const offloaded = await db.stubs();
+```
+
 #### `.close()`
 
 Forcibly close a client's connection to FalkorDB immediately. Calling `close` will not send further pending commands to the Redis server, or wait for or parse outstanding responses.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ offloaded graphs, so `stubs()` is how you tell which of the listed graphs are no
 without that module the call rejects with an "unknown command" error — treat that as
 "offloading is not supported here".
 
+On a cluster the replies of all master nodes are combined. If only some masters fail, the
+partial result is returned and the failures are logged; the call rejects only when every
+master fails.
+
 ```typescript
 const offloaded = await db.stubs();
 ```

--- a/docker/cluster-compose.yml
+++ b/docker/cluster-compose.yml
@@ -26,7 +26,7 @@ services:
         echo "cluster-config-file /data/nodes.conf"                 >> /data/node.conf
         echo "cluster-node-timeout 5000"                            >> /data/node.conf
         echo "cluster-announce-hostname node0"                      >> /data/node.conf
-        echo "cluster-announce-ip node0"                            >> /data/node.conf
+        echo "cluster-announce-ip $(hostname -i | awk '{print $1}')" >> /data/node.conf
         echo "cluster-announce-port 17000"                          >> /data/node.conf
         redis-server /data/node.conf
   node1:
@@ -56,7 +56,7 @@ services:
         echo "cluster-config-file /data/nodes.conf"                 >> /data/node.conf
         echo "cluster-node-timeout 5000"                            >> /data/node.conf
         echo "cluster-announce-hostname node1"                      >> /data/node.conf
-        echo "cluster-announce-ip node1"                            >> /data/node.conf
+        echo "cluster-announce-ip $(hostname -i | awk '{print $1}')" >> /data/node.conf
         echo "cluster-announce-port 17001"                          >> /data/node.conf
         redis-server /data/node.conf
   node2:
@@ -86,7 +86,7 @@ services:
         echo "cluster-config-file /data/nodes.conf"                >> /data/node.conf
         echo "cluster-node-timeout 5000"                           >> /data/node.conf
         echo "cluster-announce-hostname node2"                     >> /data/node.conf
-        echo "cluster-announce-ip node2"                           >> /data/node.conf
+        echo "cluster-announce-ip $(hostname -i | awk '{print $1}')" >> /data/node.conf
         echo "cluster-announce-port 17002"                         >> /data/node.conf
         redis-server /data/node.conf
   node3:
@@ -116,7 +116,7 @@ services:
         echo "cluster-config-file /data/nodes.conf"               >> /data/node.conf
         echo "cluster-node-timeout 5000"                          >> /data/node.conf
         echo "cluster-announce-hostname node3"                    >> /data/node.conf
-        echo "cluster-announce-ip node3"                          >> /data/node.conf
+        echo "cluster-announce-ip $(hostname -i | awk '{print $1}')" >> /data/node.conf
         echo "cluster-announce-port 17003"                        >> /data/node.conf
         redis-server /data/node.conf
   node4:
@@ -146,7 +146,7 @@ services:
         echo "cluster-config-file /data/nodes.conf"             >> /data/node.conf
         echo "cluster-node-timeout 5000"                        >> /data/node.conf
         echo "cluster-announce-hostname node4"                  >> /data/node.conf
-        echo "cluster-announce-ip node4"                        >> /data/node.conf
+        echo "cluster-announce-ip $(hostname -i | awk '{print $1}')" >> /data/node.conf
         echo "cluster-announce-port 17004"                      >> /data/node.conf
         redis-server /data/node.conf
 
@@ -177,7 +177,7 @@ services:
         echo "cluster-config-file /data/nodes.conf"           >> /data/node.conf
         echo "cluster-node-timeout 5000"                      >> /data/node.conf
         echo "cluster-announce-hostname node5"                >> /data/node.conf
-        echo "cluster-announce-ip node5"                      >> /data/node.conf
+        echo "cluster-announce-ip $(hostname -i | awk '{print $1}')" >> /data/node.conf
         echo "cluster-announce-port 17005"                    >> /data/node.conf
         redis-server /data/node.conf
   cluster-creator:

--- a/src/clients/client.ts
+++ b/src/clients/client.ts
@@ -12,6 +12,15 @@ export interface Client {
 
   list(): Promise<Array<string>>;
 
+  /**
+   * Lists the graphs that are currently offloaded to disk ("stubs").
+   *
+   * `GRAPH.STUBS` is provided by the FalkorDB Enterprise graph-offloading
+   * module, so it rejects with an "unknown command" error on deployments where
+   * that module is not loaded.
+   */
+  stubs(): Promise<Array<string>>;
+
   configGet(
     configKey: string
   ): Promise<(string | number)[] | (string | number)[][]>;

--- a/src/clients/cluster.ts
+++ b/src/clients/cluster.ts
@@ -106,6 +106,24 @@ export class Cluster implements Client {
     return result;
   }
 
+  async stubs(): Promise<Array<string>> {
+    const reply = await Promise.all(
+      this.#client.masters.map(async (master) => {
+        return (await this.#client.nodeClient(master)).falkordb.stubs();
+      })
+    );
+    const [result, errors] = [
+      reply.filter((r) => !(r instanceof Error)).flat(),
+      reply.filter((r) => r instanceof Error),
+    ];
+
+    if (errors.length > 0) {
+      console.error("Some nodes failed to respond:", errors);
+    }
+
+    return result;
+  }
+
   async configGet(configKey: string) {
     return this.#client.falkordb.configGet(configKey);
   }

--- a/src/clients/cluster.ts
+++ b/src/clients/cluster.ts
@@ -107,15 +107,27 @@ export class Cluster implements Client {
   }
 
   async stubs(): Promise<Array<string>> {
-    const reply = await Promise.all(
+    const replies = await Promise.allSettled(
       this.#client.masters.map(async (master) => {
         return (await this.#client.nodeClient(master)).falkordb.stubs();
       })
     );
-    const [result, errors] = [
-      reply.filter((r) => !(r instanceof Error)).flat(),
-      reply.filter((r) => r instanceof Error),
-    ];
+
+    const result: Array<string> = [];
+    const errors: Array<unknown> = [];
+    for (const reply of replies) {
+      if (reply.status === "fulfilled") {
+        result.push(...reply.value);
+      } else {
+        errors.push(reply.reason);
+      }
+    }
+
+    // Only surface a failure when every master failed - e.g. when the
+    // graph-offloading module is missing cluster-wide ("unknown command").
+    if (errors.length > 0 && errors.length === replies.length) {
+      throw errors[0];
+    }
 
     if (errors.length > 0) {
       console.error("Some nodes failed to respond:", errors);

--- a/src/clients/nullClient.ts
+++ b/src/clients/nullClient.ts
@@ -29,6 +29,9 @@ export class NullClient implements Client {
   list(): Promise<Array<string>> {
       throw new Error("Method not implemented.");
   }
+  stubs(): Promise<Array<string>> {
+      throw new Error("Method not implemented.");
+  }
   configGet(_configKey: string): Promise<(string | number)[] | (string | number)[][]> {
       throw new Error("Method not implemented.");
   }

--- a/src/clients/single.ts
+++ b/src/clients/single.ts
@@ -64,6 +64,10 @@ export class Single implements Client {
     return this.client.falkordb.list();
   }
 
+  async stubs() {
+    return this.client.falkordb.stubs();
+  }
+
   async configGet(configKey: string) {
     return this.client.falkordb.configGet(configKey);
   }

--- a/src/commands/CONFIG_GET.spec.ts
+++ b/src/commands/CONFIG_GET.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './CONFIG_GET';

--- a/src/commands/CONFIG_SET.spec.ts
+++ b/src/commands/CONFIG_SET.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './CONFIG_SET';

--- a/src/commands/CONSTRAINT_CREATE.spec.ts
+++ b/src/commands/CONSTRAINT_CREATE.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { ConstraintType, EntityType, transformArguments } from './CONSTRAINT_CREATE';

--- a/src/commands/CONSTRAINT_DROP.spec.ts
+++ b/src/commands/CONSTRAINT_DROP.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './CONSTRAINT_DROP';

--- a/src/commands/COPY.spec.ts
+++ b/src/commands/COPY.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './COPY';

--- a/src/commands/DELETE.spec.ts
+++ b/src/commands/DELETE.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './DELETE';

--- a/src/commands/EXPLAIN.spec.ts
+++ b/src/commands/EXPLAIN.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './EXPLAIN';

--- a/src/commands/INFO.spec.ts
+++ b/src/commands/INFO.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import { transformArguments, IS_READ_ONLY } from './INFO';
 

--- a/src/commands/LIST.spec.ts
+++ b/src/commands/LIST.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './LIST';

--- a/src/commands/PROFILE.spec.ts
+++ b/src/commands/PROFILE.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './PROFILE';

--- a/src/commands/QUERY.spec.ts
+++ b/src/commands/QUERY.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './QUERY';

--- a/src/commands/RO_QUERY.spec.ts
+++ b/src/commands/RO_QUERY.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './RO_QUERY';

--- a/src/commands/SENTINEL_MASTER.spec.ts
+++ b/src/commands/SENTINEL_MASTER.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import { transformArguments } from './SENTINEL_MASTER';
 

--- a/src/commands/SENTINEL_MASTERS.spec.ts
+++ b/src/commands/SENTINEL_MASTERS.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import { transformArguments } from './SENTINEL_MASTERS';
 

--- a/src/commands/SLOWLOG.spec.ts
+++ b/src/commands/SLOWLOG.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './SLOWLOG';

--- a/src/commands/STUBS.spec.ts
+++ b/src/commands/STUBS.spec.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from 'assert';
+import { transformArguments, transformReply, IS_READ_ONLY } from './STUBS';
+
+describe('STUBS', () => {
+    it('transformArguments', () => {
+        assert.deepEqual(
+            transformArguments(),
+            ['GRAPH.STUBS']
+        );
+    });
+
+    it('IS_READ_ONLY', () => {
+        assert.equal(IS_READ_ONLY, true);
+    });
+
+    it('transformReply', () => {
+        assert.deepEqual(
+            transformReply(['offloaded-graph', 'another-graph']),
+            ['offloaded-graph', 'another-graph']
+        );
+    });
+});

--- a/src/commands/STUBS.spec.ts
+++ b/src/commands/STUBS.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import { transformArguments, transformReply, IS_READ_ONLY } from './STUBS';
 

--- a/src/commands/STUBS.ts
+++ b/src/commands/STUBS.ts
@@ -1,0 +1,15 @@
+import { CommandParser } from '@redis/client';
+
+export const IS_READ_ONLY = true;
+
+export function parseCommand(parser: CommandParser): void {
+    parser.push('GRAPH.STUBS');
+}
+
+export function transformArguments(): Array<string> {
+    return ['GRAPH.STUBS'];
+}
+
+export function transformReply(reply: unknown): Array<string> {
+    return reply as Array<string>;
+}

--- a/src/commands/UDF_DELETE.spec.ts
+++ b/src/commands/UDF_DELETE.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './UDF_DELETE';

--- a/src/commands/UDF_FLUSH.spec.ts
+++ b/src/commands/UDF_FLUSH.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './UDF_FLUSH';

--- a/src/commands/UDF_LIST.spec.ts
+++ b/src/commands/UDF_LIST.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './UDF_LIST';

--- a/src/commands/UDF_LOAD.spec.ts
+++ b/src/commands/UDF_LOAD.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './UDF_LOAD';

--- a/src/commands/index.spec.ts
+++ b/src/commands/index.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it } from '@jest/globals';
 import { strict as assert } from 'assert';
 import { pushQueryArguments } from '.';
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,6 +8,7 @@ import * as PROFILE from './PROFILE';
 import * as QUERY from './QUERY';
 import * as RO_QUERY from './RO_QUERY';
 import * as SLOWLOG from './SLOWLOG';
+import * as STUBS from './STUBS';
 import * as CONSTRAINT_CREATE from './CONSTRAINT_CREATE';
 import * as CONSTRAINT_DROP from './CONSTRAINT_DROP';
 import * as COPY from './COPY';
@@ -42,6 +43,8 @@ export default {
     roQuery: RO_QUERY,
     SLOWLOG,
     slowLog: SLOWLOG,
+    STUBS,
+    stubs: STUBS,
     CONSTRAINT_CREATE,
     constraintCreate: CONSTRAINT_CREATE,
     CONSTRAINT_DROP,

--- a/src/falkordb.ts
+++ b/src/falkordb.ts
@@ -161,6 +161,18 @@ export default class FalkorDB extends EventEmitter {
         return this.#client.list()
     }
 
+    /**
+     * Lists the graphs that are currently offloaded to disk ("stubs").
+     *
+     * `GRAPH.STUBS` is provided by the FalkorDB Enterprise graph-offloading
+     * module, so this rejects with an "unknown command" error on deployments
+     * where that module is not loaded. Callers that support both editions
+     * should treat such a rejection as "no offloading support".
+     */
+    async stubs() {
+        return this.#client.stubs()
+    }
+
     async configGet(configKey: string) {
         return this.#client.configGet(configKey)
     }

--- a/src/graph.spec.ts
+++ b/src/graph.spec.ts
@@ -1,3 +1,4 @@
+import { describe } from '@jest/globals';
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from './test-utils';
 import Graph, { GraphClientType } from './graph';

--- a/tests/cluster.spec.ts
+++ b/tests/cluster.spec.ts
@@ -1,6 +1,6 @@
+import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
 import FalkorDB from '../src/falkordb';
 import { ConstraintType, EntityType } from '../src/graph';
-import { expect } from '@jest/globals';
 
 function getRandomNumber(): number {
     return Math.floor(Math.random() * 999999);

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { jest, describe, it, expect } from '@jest/globals';
 import * as UDF_LOAD from '../src/commands/UDF_LOAD';
 import * as UDF_LIST from '../src/commands/UDF_LIST';
 import * as UDF_DELETE from '../src/commands/UDF_DELETE';

--- a/tests/commands.spec.ts
+++ b/tests/commands.spec.ts
@@ -9,6 +9,7 @@ import * as SLOWLOG from '../src/commands/SLOWLOG';
 import * as CONFIG_GET from '../src/commands/CONFIG_GET';
 import * as CONFIG_SET from '../src/commands/CONFIG_SET';
 import * as LIST from '../src/commands/LIST';
+import * as STUBS from '../src/commands/STUBS';
 import * as DELETE from '../src/commands/DELETE';
 import * as COPY from '../src/commands/COPY';
 import * as EXPLAIN from '../src/commands/EXPLAIN';
@@ -332,6 +333,24 @@ describe('Command Transformation Functions', () => {
     it('should transform arguments', () => {
       const result = LIST.transformArguments();
       expect(result).toEqual(['GRAPH.LIST']);
+    });
+  });
+
+  describe('STUBS', () => {
+    it('should transform arguments', () => {
+      const result = STUBS.transformArguments();
+      expect(result).toEqual(['GRAPH.STUBS']);
+    });
+
+    it('should be marked read only', () => {
+      expect(STUBS.IS_READ_ONLY).toBe(true);
+    });
+
+    it('should transform the reply into a list of graph names', () => {
+      expect(STUBS.transformReply(['offloaded', 'another'])).toEqual([
+        'offloaded',
+        'another'
+      ]);
     });
   });
 

--- a/tests/constraints.spec.ts
+++ b/tests/constraints.spec.ts
@@ -1,5 +1,5 @@
+import { describe, it, beforeAll, beforeEach, afterAll, afterEach, expect } from '@jest/globals';
 import { client } from './dbConnection';
-import { expect } from '@jest/globals';
 import FalkorDB from '../src/falkordb';
 import Graph, { ConstraintType, EntityType } from '../src/graph';
 

--- a/tests/createClient.spec.ts
+++ b/tests/createClient.spec.ts
@@ -1,5 +1,5 @@
+import { describe, it, expect } from '@jest/globals';
 import { client } from './dbConnection';
-import { expect } from '@jest/globals';
 
 describe('FalkorDB Client', () => {
     it('create a FalkorDB client instance validated existing', async () => {

--- a/tests/graphAndQuery.spec.ts
+++ b/tests/graphAndQuery.spec.ts
@@ -1,7 +1,7 @@
+import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
 import FalkorDB from "../src/falkordb";
 import { ConstraintType, EntityType } from "../src/graph";
 import { client } from "./dbConnection";
-import { expect } from "@jest/globals";
 import { Temporal } from "@js-temporal/polyfill";
 
 function getRandomNumber(): number {

--- a/tests/indices.spec.ts
+++ b/tests/indices.spec.ts
@@ -1,5 +1,5 @@
+import { describe, it, beforeAll, beforeEach, afterAll, afterEach, expect } from '@jest/globals';
 import { client } from './dbConnection';
-import { expect } from '@jest/globals';
 import FalkorDB from '../src/falkordb';
 import Graph from '../src/graph';
 

--- a/tests/nullClient.spec.ts
+++ b/tests/nullClient.spec.ts
@@ -1,6 +1,6 @@
+import { describe, it, beforeEach, expect } from '@jest/globals';
 import { NullClient } from "../src/clients/nullClient";
 import { ConstraintType, EntityType } from "../src/graph";
-import { expect } from "@jest/globals";
 
 describe("NullClient Tests", () => {
   let nullClient: NullClient;

--- a/tests/nullClient.spec.ts
+++ b/tests/nullClient.spec.ts
@@ -36,6 +36,10 @@ describe("NullClient Tests", () => {
       expect(() => nullClient.list()).toThrow("Method not implemented.");
     });
 
+    it("should throw error on stubs", () => {
+      expect(() => nullClient.stubs()).toThrow("Method not implemented.");
+    });
+
     it("should throw error on delete", () => {
       expect(() => nullClient.delete("test-graph")).toThrow(
         "Method not implemented."

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -1,5 +1,5 @@
+import { describe, test, beforeAll, beforeEach, afterAll, afterEach, expect } from '@jest/globals';
 import { client } from './dbConnection';
-import { expect } from '@jest/globals';
 import FalkorDB from '../src/falkordb';
 import Graph from '../src/graph';
 

--- a/tests/sentinel.spec.ts
+++ b/tests/sentinel.spec.ts
@@ -1,6 +1,6 @@
+import { jest, describe, it, beforeAll, beforeEach, afterAll, expect } from '@jest/globals';
 import FalkorDB from '../src/falkordb';
 import { ConstraintType, EntityType } from '../src/graph';
-import { expect } from '@jest/globals';
 import { Sentinel } from '../src/clients/sentinel';
 
 describe('Sentinel Integration Tests', () => {
@@ -35,7 +35,7 @@ describe('Sentinel Integration Tests', () => {
 
     beforeEach(() => {
         if (!sentinelClient) {
-            pending('Skipping sentinel tests - no sentinel available');
+            console.warn('Skipping sentinel tests - no sentinel available');
         }
     });
     
@@ -365,7 +365,7 @@ describe('Sentinel Integration Tests', () => {
       const fakeClient: any = {
         options: {},
         falkordb: {
-          sentinelMasters: jest.fn().mockResolvedValue([
+          sentinelMasters: jest.fn<() => Promise<string[][]>>().mockResolvedValue([
             ['ip', '127.0.0.1', 'port', '6379'],
             ['ip', '127.0.0.2', 'port', '6380'],
           ]),

--- a/tests/single.spec.ts
+++ b/tests/single.spec.ts
@@ -1,8 +1,8 @@
+import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
 import FalkorDB from "../src/falkordb";
 import { Single } from "../src/clients/single";
 import { ConstraintType, EntityType } from "../src/graph";
 import { client } from "./dbConnection";
-import { expect } from "@jest/globals";
 
 function getRandomNumber(): number {
   return Math.floor(Math.random() * 999999);
@@ -19,16 +19,12 @@ describe("Single Client Tests", () => {
       console.error("Failed to connect to FalkorDB:", error);
     }
 
-    // Pooled client to test pool execution paths
+    // Second client to exercise the non-shared connection execution paths
     try {
       pooledClient = await FalkorDB.connect({
         socket: {
           host: process.env.FALKORDB_HOST || "localhost",
           port: parseInt(process.env.FALKORDB_PORT || "6379", 10),
-        },
-        poolOptions: {
-          min: 1,
-          max: 10,
         },
       });
     } catch (error) {

--- a/tests/stubs.spec.ts
+++ b/tests/stubs.spec.ts
@@ -1,0 +1,103 @@
+import { jest, describe, it, expect, afterEach } from '@jest/globals';
+import * as redisClient from '@redis/client';
+import type { CommandParser } from '@redis/client';
+import FalkorDB from '../src/falkordb';
+import { Single, SingleGraphConnection } from '../src/clients/single';
+import { Cluster } from '../src/clients/cluster';
+import * as STUBS from '../src/commands/STUBS';
+
+type StubsFn = () => Promise<Array<string>>;
+
+function fakeConnection(stubs: StubsFn): SingleGraphConnection {
+  return {
+    options: {},
+    disconnect: jest.fn(),
+    falkordb: { stubs },
+  } as unknown as SingleGraphConnection;
+}
+
+function fakeCluster(masters: Array<StubsFn>): Cluster {
+  const cluster = {
+    masters: masters.map((stubs, index) => ({ id: `master-${index}`, stubs })),
+    nodeClient: (master: { stubs: StubsFn }) =>
+      Promise.resolve({ falkordb: { stubs: master.stubs } }),
+  };
+
+  jest
+    .spyOn(redisClient, 'createCluster')
+    .mockReturnValue(cluster as unknown as ReturnType<typeof redisClient.createCluster>);
+
+  return new Cluster(fakeConnection(async () => []));
+}
+
+describe('STUBS command', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should push GRAPH.STUBS onto the command parser', () => {
+    const parser = { push: jest.fn() };
+
+    STUBS.parseCommand(parser as unknown as CommandParser);
+
+    expect(parser.push).toHaveBeenCalledWith('GRAPH.STUBS');
+  });
+
+  describe('Single', () => {
+    it('should delegate to the underlying connection', async () => {
+      const single = new Single(fakeConnection(async () => ['offloaded']));
+
+      await expect(single.stubs()).resolves.toEqual(['offloaded']);
+    });
+  });
+
+  describe('FalkorDB', () => {
+    it('should reject when no client is connected', async () => {
+      await expect(new FalkorDB().stubs()).rejects.toThrow('Method not implemented.');
+    });
+  });
+
+  describe('Cluster', () => {
+    it('should aggregate the replies of all masters', async () => {
+      const cluster = fakeCluster([
+        async () => ['graph-a'],
+        async () => ['graph-b', 'graph-c'],
+      ]);
+
+      await expect(cluster.stubs()).resolves.toEqual(['graph-a', 'graph-b', 'graph-c']);
+    });
+
+    it('should return partial results when some masters fail', async () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const failure = new Error('node down');
+      const cluster = fakeCluster([
+        async () => ['graph-a'],
+        async () => {
+          throw failure;
+        },
+      ]);
+
+      await expect(cluster.stubs()).resolves.toEqual(['graph-a']);
+      expect(consoleError).toHaveBeenCalledWith('Some nodes failed to respond:', [failure]);
+    });
+
+    it('should reject when every master fails', async () => {
+      const cluster = fakeCluster([
+        async () => {
+          throw new Error('unknown command `GRAPH.STUBS`');
+        },
+        async () => {
+          throw new Error('unknown command `GRAPH.STUBS`');
+        },
+      ]);
+
+      await expect(cluster.stubs()).rejects.toThrow('unknown command `GRAPH.STUBS`');
+    });
+
+    it('should resolve to an empty list when there are no masters', async () => {
+      const cluster = fakeCluster([]);
+
+      await expect(cluster.stubs()).resolves.toEqual([]);
+    });
+  });
+});

--- a/tests/udf.spec.ts
+++ b/tests/udf.spec.ts
@@ -1,6 +1,6 @@
+import { describe, it, beforeAll, afterAll, expect } from '@jest/globals';
 import FalkorDB from "../src/falkordb";
 import { client } from "./dbConnection";
-import { expect } from "@jest/globals";
 
 describe("UDF API Tests", () => {
   let falkorClient: FalkorDB;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": false,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "types": ["jest"],
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `stubs()` to fetch graphs offloaded to disk but not currently loaded in memory.
  * Enabled stub retrieval for single-node and clustered deployments, aggregating results across masters.
  * Introduced the `GRAPH.STUBS` read-only command with proper argument/reply handling.
* **Documentation**
  * Updated the README Usage section to describe `db.stubs()` behavior and the “unknown command” response when offloading isn’t supported.
* **Tests**
  * Added/extended tests for command behavior, client support (including unimplemented client behavior), and reply transformations.
* **Chores**
  * Ensured Jest type declarations are included in TypeScript compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->