### PR TITLE
ci: stop the test job from hanging for six hours

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -196,7 +196,10 @@ jobs:
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [build]
-    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    # `cancelled` as well as `failure`: a job stopped by its own timeout, or one
+    # that ran into GitHub's six hour ceiling, reports `cancelled`, and a nightly
+    # that hangs is exactly the case this alert exists for.
+    if: ${{ always() && github.event_name == 'schedule' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
     permissions:
       issues: write
     # Pinned, and only the one secret it declares is passed: a mutable ref

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -162,6 +162,18 @@ jobs:
         FALKORDB_HOST: 127.0.0.1
         FALKORDB_PORT: 6379
     
+    - name: Dump FalkorDB server logs
+      # The suites fail with SocketClosedUnexpectedlyError, which means a server
+      # went away mid-run. These logs say whether it crashed, OOMed or restarted.
+      if: failure()
+      run: |
+        docker ps -a
+        for name in falkordb-standalone falkordb-server-1 falkordb-server-2 sentinel-1 sentinel-2 sentinel-3 node0 node1 node2 node3 node4 node5; do
+          echo "::group::$name"
+          docker logs --tail 200 "$name" 2>&1 || echo "no container named $name"
+          echo "::endgroup::"
+        done
+
     - name: Notify Google Chat
       id: test-action
       if: failure() # only send notification in case of failure

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,6 +40,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Without this the job inherits the 6 hour default, so a hung step keeps a
+    # runner busy for the rest of the day instead of failing fast.
+    timeout-minutes: 30
+
     strategy:
       matrix:
         node-version: [20.x, 22.x]

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -153,7 +153,11 @@ jobs:
         done
 
     - name: Run tests
-      run: npx jest --coverage
+      # --forceExit because jest reports "did not exit one second after the test
+      # run has completed" and then hangs forever on handles the suites leave
+      # open. The leak still needs fixing, but it should not cost a whole runner.
+      run: npx jest --coverage --forceExit
+      timeout-minutes: 15
       env:
         FALKORDB_HOST: 127.0.0.1
         FALKORDB_PORT: 6379


### PR DESCRIPTION
## What's wrong

`build (20.x)` and `build (22.x)` run forever. This is not specific to one PR — `main` has been stuck on the same step since this morning, and it has been eating runners on every open PR.

Three things are going on:

**1. Jest never exits.** The test step finishes the run and then sits there:

```
Time: 343.496 s
Ran all test suites.
Jest did not exit one second after the test run has completed.
```

Something in the suites leaves a handle open. The job has no `timeout-minutes`, so it inherits the **6 hour** default and keeps a runner busy all day before anyone notices.

**2. A server drops mid-run.** The suites fail with `SocketClosedUnexpectedlyError` and `DisconnectsClientError`, and every test after that hits the 30s timeout — one disconnect cascades into ~48 failures. We currently have no logs to tell us why the server went away.

**3. Nobody is told when the nightly dies.** Now that the `edge` image is only exercised by the daily scheduled run, that run is our only signal for upcoming engine changes. It has not produced a result once:

| Nightly run | Duration | Result | Reporter |
| --- | --- | --- | --- |
| Aug 13 | 6h00m | `cancelled` | skipped |
| Aug 14 | 6h00m | `cancelled` | skipped |
| Aug 15 | 6h00m | `cancelled` | skipped |
| Aug 16 | 6h00m | `cancelled` | skipped |

Every one hangs into GitHub's six hour ceiling. A job killed that way reports `cancelled`, but `report-scheduled-failure` only looks for `failure`, so the alert was skipped every single time. The net effect is that `edge` currently has **no coverage at all** and no alert to say so.

## What this does

- `timeout-minutes: 30` on the job and `15` on the test step, so a hang fails fast instead of burning a runner.
- `--forceExit` on jest so the process actually terminates once the run is done.
- Dumps `docker logs` for every test server when the job fails, so next time we can see whether the server crashed, OOMed or restarted.
- Alerts on a `cancelled` scheduled run as well as a failed one, so a nightly that stalls is reported instead of disappearing.

## What this does not do

`--forceExit` is a mitigation, not a fix. The open handle is still there and the server still drops connections — both need their own tickets. This PR is only about not paying for it with a runner every time, and about hearing when the nightly stops working.

## Checks

- Coverage is still written with `--forceExit` (`lcov.info`, `clover.xml`, `coverage-final.json` all produced), so the Codecov step keeps working.
- A failing suite still exits `1` with `--forceExit`, so broken tests cannot slip through green.
- Workflow YAML parses; spellcheck only scans markdown, so the added comments do not affect it.
- The reporter condition keeps its `github.event_name == 'schedule'` guard, so a cancelled PR run — the normal result of pushing a new commit — still does not raise anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added explicit time limits for build jobs and test execution to improve pipeline reliability.
  * Added automatic diagnostic log collection when builds fail.
  * Scheduled build failure reporting now also covers cancelled builds.
  * No changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
