### PR TITLE
ci(node): run tests against latest, edge daily

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -167,3 +167,36 @@ jobs:
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  # A cron job has nobody watching it: GitHub only emails the user who last
+  # touched the cron line, so a silent daily failure is the default outcome.
+  # Failures therefore open a tracking issue (or comment on the open one).
+  report-scheduled-failure:
+    name: Report scheduled failure
+    needs: [build]
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+          TITLE: "CI is failing against falkordb/falkordb:edge"
+        run: |
+          body=$(printf '%s\n' \
+            "The daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
+            "" \
+            "$RUN_URL" \
+            "" \
+            "\`edge\` is an unreleased FalkorDB build, so this does not affect users on \`latest\`: it is an early warning that something in the next FalkorDB release breaks this client.")
+          number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
+            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --body "$body"
+          else
+            gh issue create --title "$TITLE" --body "$body"
+          fi

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,10 +9,21 @@ permissions:
 on:
   push:
     branches: [ "main" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "main" ]
   release:
     types: [created]
+  # Daily run against the `edge` image to catch breaking changes in upcoming
+  # FalkorDB releases before they reach a stable release.
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      falkordb_image_tag:
+        description: "FalkorDB Docker image tag to test against (defaults to latest)"
+        required: false
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -22,6 +33,12 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+
+    # The docker/*-compose.yml files read this: released `latest` for PRs,
+    # pushes, tags and releases, `edge` for the scheduled daily run (or an
+    # explicit tag on manual dispatch).
+    env:
+      FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
 
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -168,9 +168,9 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
-  # A cron job has nobody watching it: GitHub only emails the user who last
-  # touched the cron line, so a silent daily failure is the default outcome.
-  # Failures therefore open a tracking issue (or comment on the open one).
+  # A cron job has nobody watching it: GitHub only emails whoever last touched
+  # the cron line, so a failing daily run would otherwise go unnoticed. Post it
+  # to Google Chat instead.
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [build]
@@ -178,13 +178,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    env:
+      GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}
+      REPO: ${{ github.repository }}
+      WORKFLOW: ${{ github.workflow }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      - name: Open or update the tracking issue
+      - name: Notify Google Chat
+        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL != '' }}
+        run: |
+          text=$(printf '%s\n' \
+            "*$REPO* — the daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
+            "<$RUN_URL|View the run>" \
+            "" \
+            "\`edge\` is an unreleased FalkorDB build, so released users are unaffected: this is an early warning that the next FalkorDB release breaks this client.")
+          jq -n --arg text "$text" '{text: $text}' > payload.json
+          curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' \
+            -d @payload.json "$GOOGLE_CHAT_WEBHOOK_URL"
+
+      # Fallback while the webhook secret is not configured, so the signal is
+      # never lost. Opens one issue and comments on it on subsequent failures.
+      - name: Open or update a tracking issue
+        if: ${{ env.GOOGLE_CHAT_WEBHOOK_URL == '' }}
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          WORKFLOW: ${{ github.workflow }}
           TITLE: "CI is failing against falkordb/falkordb:edge"
         run: |
           body=$(printf '%s\n' \
@@ -192,7 +210,7 @@ jobs:
             "" \
             "$RUN_URL" \
             "" \
-            "\`edge\` is an unreleased FalkorDB build, so this does not affect users on \`latest\`: it is an early warning that something in the next FalkorDB release breaks this client.")
+            "Set the \`GOOGLE_CHAT_WEBHOOK_URL\` secret to receive this in Google Chat instead.")
           number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
             --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
           if [ -n "$number" ]; then

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,16 +29,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # FalkorDB image tag under test, read by the docker/*-compose.yml files: the
+  # released `latest` for pull requests, pushes, tags and releases, `edge` for
+  # the scheduled daily run, or an explicit tag on manual dispatch.
+  FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    # The docker/*-compose.yml files read this: released `latest` for PRs,
-    # pushes, tags and releases, `edge` for the scheduled daily run (or an
-    # explicit tag on manual dispatch).
-    env:
-      FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
 
     strategy:
       matrix:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,7 +9,7 @@ permissions:
 on:
   push:
     branches: [ "main" ]
-    tags: [ "v*" ]
+    tags: [ "v*", "[0-9]+.[0-9]+.[0-9]+" ]
   pull_request:
     branches: [ "main" ]
   release:
@@ -23,7 +23,7 @@ on:
       falkordb_image_tag:
         description: "FalkorDB Docker image tag to test against (defaults to latest)"
         required: false
-        default: ""
+        default: "latest"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/docker/cluster-compose.yml
+++ b/docker/cluster-compose.yml
@@ -1,6 +1,6 @@
 services:
   node0:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: node0
     hostname: node0
     ports:
@@ -30,7 +30,7 @@ services:
         echo "cluster-announce-port 17000"                          >> /data/node.conf
         redis-server /data/node.conf
   node1:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: node1
     hostname: node1
     ports:
@@ -60,7 +60,7 @@ services:
         echo "cluster-announce-port 17001"                          >> /data/node.conf
         redis-server /data/node.conf
   node2:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: node2
     hostname: node2
     ports:
@@ -90,7 +90,7 @@ services:
         echo "cluster-announce-port 17002"                         >> /data/node.conf
         redis-server /data/node.conf
   node3:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: node3
     hostname: node3
     ports:
@@ -120,7 +120,7 @@ services:
         echo "cluster-announce-port 17003"                        >> /data/node.conf
         redis-server /data/node.conf
   node4:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: node4
     hostname: node4
     ports:
@@ -151,7 +151,7 @@ services:
         redis-server /data/node.conf
 
   node5:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: node5
     hostname: node5
     ports:
@@ -181,7 +181,7 @@ services:
         echo "cluster-announce-port 17005"                    >> /data/node.conf
         redis-server /data/node.conf
   cluster-creator:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: cluster-creator
     hostname: cluster-creator
     depends_on:

--- a/docker/sentinel-compose.yml
+++ b/docker/sentinel-compose.yml
@@ -1,6 +1,6 @@
 services:
   sentinel-1:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: sentinel-1
     hostname: sentinel-1
     restart: always
@@ -28,7 +28,7 @@ services:
         redis-server /data/sentinel.conf --sentinel
 
   sentinel-2:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: sentinel-2
     hostname: sentinel-2
     restart: always
@@ -56,7 +56,7 @@ services:
         redis-server /data/sentinel.conf --sentinel
   
   sentinel-3:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     container_name: sentinel-3
     hostname: sentinel-3
     restart: always
@@ -84,7 +84,7 @@ services:
         redis-server /data/sentinel.conf --sentinel
 
   falkordb-server-1:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     hostname: falkordb-server-1
     container_name: falkordb-server-1
     ports:
@@ -109,7 +109,7 @@ services:
         redis-server /data/node.conf
   
   falkordb-server-2:
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     hostname: falkordb-server-2
     container_name: falkordb-server-2
     ports:

--- a/docker/standalone-compose.yml
+++ b/docker/standalone-compose.yml
@@ -2,7 +2,7 @@ services:
   falkordb-standalone:
     container_name: falkordb-standalone
     hostname: falkordb-standalone
-    image: falkordb/falkordb:edge
+    image: falkordb/falkordb:${FALKORDB_VERSION:-latest}
     ports:
     - 6379:6379
     healthcheck:


### PR DESCRIPTION
## Summary
The docker compose stacks that back CI hardcoded `falkordb/falkordb:edge`, so every PR, push and release was validated against an unreleased build while nothing ever tested the client against the FalkorDB version users actually run. The image tag is now configurable, defaults to the released `latest`, and `edge` moves to a daily scheduled run where an upstream break is an early warning instead of a merge blocker.

## Changes
- `docker/standalone-compose.yml`, `docker/sentinel-compose.yml`, `docker/cluster-compose.yml`: image is now `falkordb/falkordb:${FALKORDB_VERSION:-latest}` (13 services in total), so local `docker compose up` keeps working unchanged and defaults to `latest`.
- `node.js.yml`: `FALKORDB_VERSION` is defined once at the workflow level — `latest` for pull requests, pushes to `main`, tags (`v*` — newly added trigger) and releases, `edge` on the new daily schedule (02:00 UTC).
- New `workflow_dispatch` with an optional `falkordb_image_tag` input to test an arbitrary tag on demand.

Job names are unchanged, so existing branch-protection required checks keep working.

## The standard, in all seven clients
Every official client picks the image tag with the same expression:

```
${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
```

`latest` for pull requests, pushes, tags and releases; `edge` for the daily scheduled run; any tag on manual dispatch.

Clients that start FalkorDB with docker compose (falkordb-ts, falkordb-php) keep it in a workflow-level `FALKORDB_VERSION`, which compose reads as `falkordb/falkordb:${FALKORDB_VERSION:-latest}`.

Clients that run FalkorDB as a **service container** keep doing exactly that — the service container is the idiomatic mechanism and gets networking, health checks and cleanup from the runner for free. The tag still has a single definition, but it cannot be an `env:` variable: GitHub does not allow the `env` context in `jobs.<id>.services.<id>.image` ([context availability](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#context-availability)). A small `falkordb-version` job resolves it once and every job consumes it:

```yaml
jobs:
  falkordb-version:
    name: Resolve FalkorDB version
    runs-on: ubuntu-latest
    outputs:
      version: ${{ steps.resolve.outputs.version }}
    steps:
      - id: resolve
        env:
          FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
        run: echo "version=$FALKORDB_VERSION" >> "$GITHUB_OUTPUT"

  test:
    needs: falkordb-version
    services:
      falkordb:
        image: falkordb/falkordb:${{ needs.falkordb-version.outputs.version }}
```

## Failure notifications
The daily `edge` run posts to Google Chat when it fails. GitHub itself only emails whoever last edited the cron line, so without this the early-warning run would fail silently.

Add a Google Chat **incoming webhook** for the target space and store it as an Actions secret named `GOOGLE_CHAT_WEBHOOK_URL` — ideally once at organisation level so all seven clients share it:

```bash
gh secret set GOOGLE_CHAT_WEBHOOK_URL --org FalkorDB --visibility all
```

Until that secret exists the job falls back to opening (or commenting on) a tracking issue, so the signal is never lost. The step only runs on `schedule` failures; manual and PR runs are already visible to whoever triggered them. The message is built with `jq`, and no `${{ }}` expression is expanded into the shell.

## Testing
- `docker compose -f docker/<file>.yml config` verified locally: resolves to `falkordb/falkordb:latest` by default and `falkordb/falkordb:edge` with `FALKORDB_VERSION=edge`, for every service in all three stacks.
- Verified by this PR's own runs (standalone/sentinel/cluster containers must come up on `latest`).

## Memory / Performance Impact
N/A — CI configuration only.

## Related Issues
N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible container image version selection for standalone, clustered, and Sentinel deployments.
  * Image versions can now be selected during manual workflow runs, with scheduled builds using the edge image and other runs defaulting to the latest image.
  * Added support for triggering workflows on semantic-version tags and on a daily schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
