### PR TITLE
ci: use the shared report-scheduled-failure workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -169,52 +169,15 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   # A cron job has nobody watching it: GitHub only emails whoever last touched
-  # the cron line, so a failing daily run would otherwise go unnoticed. Post it
-  # to Google Chat instead.
+  # the cron line, so a failing daily run would otherwise go unnoticed. The
+  # reporter is shared with the other FalkorDB clients, which all need the same
+  # alert; `permissions` has to stay here because a called workflow can only
+  # downgrade the caller's token.
   report-scheduled-failure:
     name: Report scheduled failure
     needs: [build]
     if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
-    runs-on: ubuntu-latest
     permissions:
       issues: write
-    env:
-      DRIVERS_GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL }}
-      REPO: ${{ github.repository }}
-      WORKFLOW: ${{ github.workflow }}
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-    steps:
-      - name: Notify Google Chat
-        if: ${{ env.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL != '' }}
-        run: |
-          text=$(printf '%s\n' \
-            "*$REPO* — the daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
-            "<$RUN_URL|View the run>" \
-            "" \
-            "\`edge\` is an unreleased FalkorDB build, so released users are unaffected: this is an early warning that the next FalkorDB release breaks this client.")
-          jq -n --arg text "$text" '{text: $text}' > payload.json
-          curl -sS --fail-with-body -X POST -H 'Content-Type: application/json' \
-            -d @payload.json "$DRIVERS_GOOGLE_CHAT_WEBHOOK_URL"
-
-      # Fallback while the webhook secret is not configured, so the signal is
-      # never lost. Opens one issue and comments on it on subsequent failures.
-      - name: Open or update a tracking issue
-        if: ${{ env.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL == '' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TITLE: "CI is failing against falkordb/falkordb:edge"
-        run: |
-          body=$(printf '%s\n' \
-            "The daily \`$WORKFLOW\` run against \`falkordb/falkordb:edge\` failed." \
-            "" \
-            "$RUN_URL" \
-            "" \
-            "Set the \`DRIVERS_GOOGLE_CHAT_WEBHOOK_URL\` secret to receive this in Google Chat instead.")
-          number=$(gh issue list --state open --search "$TITLE in:title" --json number,title \
-            --jq "map(select(.title == \"$TITLE\")) | .[0].number // empty")
-          if [ -n "$number" ]; then
-            gh issue comment "$number" --body "$body"
-          else
-            gh issue create --title "$TITLE" --body "$body"
-          fi
+    uses: FalkorDB/.github/.github/workflows/report-scheduled-failure.yml@main
+    secrets: inherit

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -179,5 +179,9 @@ jobs:
     if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
     permissions:
       issues: write
-    uses: FalkorDB/.github/.github/workflows/report-scheduled-failure.yml@main
-    secrets: inherit
+    # Pinned, and only the one secret it declares is passed: a mutable ref
+    # plus `secrets: inherit` would let a later upstream change run with this
+    # repo's secrets. Dependabot keeps the pin current.
+    uses: FalkorDB/.github/.github/workflows/report-scheduled-failure.yml@12e1ec11c97c5a19f3d228224cacc50fe0ea6e9d # 2026-08-13
+    secrets:
+      DRIVERS_GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -182,6 +182,6 @@ jobs:
     # Pinned, and only the one secret it declares is passed: a mutable ref
     # plus `secrets: inherit` would let a later upstream change run with this
     # repo's secrets. Dependabot keeps the pin current.
-    uses: FalkorDB/.github/.github/workflows/report-scheduled-failure.yml@12e1ec11c97c5a19f3d228224cacc50fe0ea6e9d # 2026-08-13
+    uses: FalkorDB/.github/.github/workflows/report-scheduled-failure.yml@126ec30105d98bdfb62b5631e92aa149fc0e5ad1 # 2026-08-13
     secrets:
       DRIVERS_GOOGLE_CHAT_WEBHOOK_URL: ${{ secrets.DRIVERS_GOOGLE_CHAT_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
The `report-scheduled-failure` job that alerts the drivers team when the nightly run against `falkordb/falkordb:edge` breaks is duplicated across every official [FalkorDB client](https://docs.falkordb.com/getting-started/clients.html) — 8 copies in 7 repos (falkordb-ts, falkordb-py, falkordb-go, falkordb-rs ×2, falkordb-php, JFalkorDB, NFalkorDB). 7 of them are byte-identical.

FalkorDB/.github#5 hosts the job once as a reusable (`workflow_call`) workflow. This PR makes falkordb-ts the first caller: 43 lines of duplicated shell become 6.

## Changes
- Replace the inlined `report-scheduled-failure` job body with a pinned `uses:` of the shared workflow, passing only `DRIVERS_GOOGLE_CHAT_WEBHOOK_URL`.
- Keep `needs:`, `if:` and `permissions:` here — only this repo knows which jobs must have failed, and a called workflow can only downgrade the caller's token, never upgrade it, so `issues: write` has to be granted by the caller.

No behaviour change. The `github` context inside a called workflow belongs to the *caller*, so `github.repository`, `github.workflow` and the run URL in the alert resolve exactly as before.

## Testing
- `actionlint` passes on the modified workflow.
- Diffed the shared job body against the copy removed here: identical apart from the tracking issue title becoming an input (defaulted to the value used here).
- CI on this PR exercises the `uses:` reference resolving; the job itself only runs on a scheduled failure, so it will first fire on the next nightly `edge` run.

## Memory / Performance Impact
N/A — CI configuration only.

## Related Issues
Depends on FalkorDB/.github#5 (merged). Remaining clients to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduled workflow failure reporting to use a standardized reusable workflow.
  * Preserved failure-only reporting for scheduled runs and secure issue-management permissions.
  * Added explicit support for sending notifications through the configured Google Chat webhook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review follow-ups
- **Pinned to a commit SHA, `secrets: inherit` dropped.** A mutable ref plus inherited secrets would let a later upstream change run with this repo's secrets. Only `DRIVERS_GOOGLE_CHAT_WEBHOOK_URL` is passed now. Pinning does not reintroduce the duplication: Dependabot updates `jobs.<id>.uses` pins and is already enabled here.
- **Two bugs fixed upstream in [FalkorDB/.github#10](https://github.com/FalkorDB/.github/pull/10)**, both inherited from the copies this replaces: the issue title was spliced into a `--jq` program (broke on a quote), and deduplication used the eventually-consistent search index, so two failures in quick succession each opened their own tracking issue. Reproduced and re-verified against a temporary harness; dedupe is now label-based.