### PR TITLE
test: assert query timeout explicitly

### DIFF
--- a/tests/graphAndQuery.spec.ts
+++ b/tests/graphAndQuery.spec.ts
@@ -288,14 +288,18 @@ describe("FalkorDB Execute Query", () => {
 
   it("Reject queries that exceed a one-second timeout", async () => {
     const graph = clientInstance.selectGraph(`graph_${getRandomNumber()}`);
+    const timeoutMs = 1000;
     await graph.query("UNWIND range(0, 1000) AS val CREATE (:Node {v: val})");
-    await expect(
-      graph.query(
-        "MATCH (a), (b), (c), (d) RETURN count(*)",
-        { TIMEOUT: 1000 }
-      )
-    ).rejects.toThrow("Query timed out");
-    await graph.delete();
+    try {
+      await expect(
+        graph.query(
+          "MATCH (a), (b), (c), (d) RETURN count(*)",
+          { TIMEOUT: timeoutMs }
+        )
+      ).rejects.toThrow("Query timed out");
+    } finally {
+      await graph.delete();
+    }
   });
 
   it("Create and match nodes with multiple labels", async () => {

--- a/tests/graphAndQuery.spec.ts
+++ b/tests/graphAndQuery.spec.ts
@@ -286,15 +286,15 @@ describe("FalkorDB Execute Query", () => {
     await graph.delete();
   });
 
-  it("Assert query execution time exceeds 1-sec limit", async () => {
+  it("Reject queries that exceed a one-second timeout", async () => {
     const graph = clientInstance.selectGraph(`graph_${getRandomNumber()}`);
     await graph.query("UNWIND range(0, 1000) AS val CREATE (:Node {v: val})");
-    const result = await graph.query("MATCH (a), (b), (c), (d) RETURN *");
-    const executionTimeStr = result.metadata[1];
-    const executionTime = parseFloat(executionTimeStr.split(": ")[1]);
-    expect(() => {
-      expect(executionTime).toBeLessThan(1);
-    }).toThrow();
+    await expect(
+      graph.query(
+        "MATCH (a), (b), (c), (d) RETURN count(*)",
+        { TIMEOUT: 1000 }
+      )
+    ).rejects.toThrow("Query timed out");
     await graph.delete();
   });
 


### PR DESCRIPTION
## Summary
- replace the hardware-dependent execution-time threshold with an explicit 1,000 ms query timeout
- force full Cartesian-product evaluation with `count(*)` and assert the engine returns `Query timed out`

## Testing
- local full CI against `falkordb/falkordb:edge` on Node.js 20: 292/292 passed
- local full CI against `falkordb/falkordb:edge` on Node.js 22: 292/292 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so queries exceeding the configured limit are rejected with a clear “Query timed out” message.
* **Tests**
  * Updated coverage to verify timeout rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->