### PR TITLE
Bump version to 6.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "falkordb",
-  "version": "0.0.0-dev",
+  "version": "6.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "falkordb",
-      "version": "0.0.0-dev",
+      "version": "6.8.0",
       "license": "MIT",
       "workspaces": [
         "./packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falkordb",
-  "version": "0.0.0-dev",
+  "version": "6.8.0",
   "description": "A FalkorDB javascript library",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump the `falkordb` package version to `6.8.0`.
- Keep the root lockfile version in sync.

## Version rationale
Since `6.7.0`, #606 added backward-compatible top-level `host` and `port` connection options. That additive public API change warrants a SemVer minor release; the other merged PRs are maintenance, CI, test, and documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 6.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->