### PR TITLE
ci: publish only after CI passes on the released commit

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,12 @@ on:
         default: "latest"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # The event name is part of the group because creating a release also creates
+  # the tag: the tag-push run and the release run would otherwise land in the
+  # same group and cancel each other, at random. publish.yml waits specifically
+  # for the release run, so losing that race would block the release. Runs for a
+  # given pull request still supersede each other, which is what this is for.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,20 +23,25 @@ jobs:
   #     a commit that is not the one it was built from.
   #
   # Polling rather than trusting whichever CI run happens to be green for this
-  # commit: the daily scheduled run tests the same tree against the `edge` image,
-  # so a nightly success from before the release could otherwise mask a release
-  # run that failed. The query is therefore narrowed to `event=release`, which is
-  # the run this release started.
+  # commit. Two runs can look right and not be:
+  #
+  #   * the daily scheduled run covers the same tree against the `edge` image, so
+  #     a nightly success from before the release would mask a release run that
+  #     failed - hence `event=release`;
+  #   * two releases can point at one commit, and CI resolves the FalkorDB image
+  #     at run time, so an older tag's success says nothing about this tag today
+  #     - hence the `head_branch` check, which for a release run holds the tag.
   await-ci:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       actions: read
     steps:
-      - name: Wait for CI to pass on ${{ github.sha }}
+      - name: Wait for CI to pass on ${{ github.event.release.tag_name }}
         env:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           # Must stay in step with the CI workflow's filename. A rename makes the
           # API call 404, which fails this job and blocks the publish rather than
           # quietly letting an untested package through.
@@ -48,23 +53,25 @@ jobs:
           while :; do
             runs=$(gh api --paginate \
               "repos/$GITHUB_REPOSITORY/actions/workflows/$CI_WORKFLOW/runs?head_sha=$HEAD_SHA&event=release&per_page=100" \
-              --jq '.workflow_runs[] | "\(.status):\(.conclusion // "none")"')
+              --jq '.workflow_runs[]
+                    | select(.head_branch == env.RELEASE_TAG)
+                    | "\(.status):\(.conclusion // "none")"')
 
             if grep -qx 'completed:success' <<<"$runs"; then
-              echo "CI passed for $HEAD_SHA."
+              echo "CI passed for $RELEASE_TAG ($HEAD_SHA)."
               exit 0
             fi
 
             # Every run is finished and none of them passed: waiting longer
             # cannot change the answer.
             if [ -n "$runs" ] && ! grep -qv '^completed:' <<<"$runs"; then
-              echo "::error::CI did not pass for $HEAD_SHA, so nothing was published."
+              echo "::error::CI did not pass for $RELEASE_TAG, so nothing was published."
               echo "$runs"
               exit 1
             fi
 
             if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "::error::Timed out waiting for CI to finish on $HEAD_SHA."
+              echo "::error::Timed out waiting for CI to finish on $RELEASE_TAG."
               echo "${runs:-no CI run found for this release}"
               exit 1
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,13 +3,81 @@ on:
   release:
     types: [created]
 
-permissions:
-  id-token: write  # Required for OIDC
-  contents: read
+# Least privilege by default; each job below asks for exactly what it needs.
+permissions: {}
 
 jobs:
-  publish:
+  # `release: created` reaches CI and this workflow at the same moment, so
+  # without a gate npm receives the package while the tests that decide whether
+  # it works are still running, and a red CI cannot stop it (#529).
+  #
+  # This waits for CI on the released commit rather than switching the workflow
+  # to `on: workflow_run:`, for two reasons:
+  #
+  #   * npm trusted publishing matches the filename of the workflow that runs
+  #     `npm publish` against the publisher registered on npmjs.com, so the
+  #     publish step has to stay in publish.yml or releases fail with ENEEDAUTH.
+  #   * a workflow_run run is stamped with the default branch, making GITHUB_REF
+  #     and GITHUB_SHA refs/heads/main and main's head. npm copies both into the
+  #     provenance attestation, which would then claim the package was built from
+  #     a commit that is not the one it was built from.
+  #
+  # Polling rather than trusting whichever CI run happens to be green for this
+  # commit: the daily scheduled run tests the same tree against the `edge` image,
+  # so a nightly success from before the release could otherwise mask a release
+  # run that failed. The query is therefore narrowed to `event=release`, which is
+  # the run this release started.
+  await-ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      actions: read
+    steps:
+      - name: Wait for CI to pass on ${{ github.sha }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.sha }}
+          # Must stay in step with the CI workflow's filename. A rename makes the
+          # API call 404, which fails this job and blocks the publish rather than
+          # quietly letting an untested package through.
+          CI_WORKFLOW: node.js.yml
+        run: |
+          set -euo pipefail
+          deadline=$(( SECONDS + 55 * 60 ))
+
+          while :; do
+            runs=$(gh api --paginate \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/$CI_WORKFLOW/runs?head_sha=$HEAD_SHA&event=release&per_page=100" \
+              --jq '.workflow_runs[] | "\(.status):\(.conclusion // "none")"')
+
+            if grep -qx 'completed:success' <<<"$runs"; then
+              echo "CI passed for $HEAD_SHA."
+              exit 0
+            fi
+
+            # Every run is finished and none of them passed: waiting longer
+            # cannot change the answer.
+            if [ -n "$runs" ] && ! grep -qv '^completed:' <<<"$runs"; then
+              echo "::error::CI did not pass for $HEAD_SHA, so nothing was published."
+              echo "$runs"
+              exit 1
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for CI to finish on $HEAD_SHA."
+              echo "${runs:-no CI run found for this release}"
+              exit 1
+            fi
+
+            sleep 20
+          done
+
+  publish:
+    needs: [await-ci]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Closes #529. Supersedes #532 (see below for why the approach changed).

Publishing ran independently of CI. `release: created` starts both workflows at the same moment, so npm could receive the package while the tests that decide whether it works were still running — and a red CI had no way to stop it.

## What changed

`publish` now depends on an `await-ci` job that polls for the CI run this release started, and **fails closed**: a failed, cancelled, missing or never-finishing run publishes nothing.

`node.js.yml`'s concurrency group gained `github.event_name` (see the third point below).

## Why not `on: workflow_run:`

That is the obvious fit and it is what #532 proposed, but it breaks two things in this repo:

1. **npm trusted publishing would stop working.** This repo has no `NPM_TOKEN` — publishing is OIDC-only. npm matches the *filename* of the workflow that runs `npm publish` against the publisher registered on npmjs.com: *"verify that the workflow filename matches exactly what you configured on npmjs.com, including the `.yml` extension. All fields are case-sensitive and must be exact."* ([docs](https://docs.npmjs.com/trusted-publishers)) So the publish step has to stay in `publish.yml`. Moving it into a reusable workflow or into `node.js.yml` fails with `ENEEDAUTH` until someone edits npm settings — a manual step outside this repo that, if forgotten, breaks the next release.

2. **Provenance would attest to the wrong commit.** A `workflow_run` run is stamped with the default branch, so `GITHUB_REF` is `refs/heads/main` and `GITHUB_SHA` is main's head rather than the released commit. [`libnpmpublish`](https://github.com/npm/cli/blob/latest/workspaces/libnpmpublish/lib/provenance.js) writes both straight into the attestation:

   ```js
   uri: `git+${env.GITHUB_SERVER_URL}/${env.GITHUB_REPOSITORY}@${env.GITHUB_REF}`,
   digest: { gitCommit: env.GITHUB_SHA },
   ```

   The package would be signed as built from a commit it was not built from — the opposite of the point of a supply-chain change. Keeping `release: created` keeps `GITHUB_REF`/`GITHUB_SHA` on the tag.

3. **A race would have decided releases at random.** Creating a release also creates the tag, so the tag-push run and the release run shared CI's concurrency group and cancelled each other. The 6.8.0 commit shows this happening for real — `push cancelled` sitting next to `release success`. Had it fallen the other way there would have been no release run to wait for, and #532 (which requires `workflow_run.event == 'release'`) would never have published. The group now includes the event name so both coexist; per-pull-request superseding is unchanged.

Also worth noting: #532's version detection was `git tag --points-at HEAD | grep -E '^(falkordb@|v)'`. This repo's tags are plain `6.8.0`, so that matches nothing and would have published an empty version. Staying on `release: created` keeps the existing `GITHUB_REF_NAME` logic, which already works.

## Which run counts

CI resolves the FalkorDB image at run time (`FALKORDB_VERSION: latest`), so a green run is not a durable property of a commit — the same tree can pass in August and fail in September against a newer server. The run therefore has to be *this release's*, matched on two things:

* `event=release`, because the daily scheduled run covers the same commit against the `edge` image, and a nightly success from before the release would otherwise mask a release run that failed. The 6.8.0 commit carries 14 green scheduled runs.
* `head_branch == github.event.release.tag_name`, because two releases can point at one commit, and the earlier tag's success says nothing about this one. Release-triggered runs carry the tag in `head_branch`.

**This has already happened.** 6.6.2's release CI run failed and 6.6.2 was published to npm regardless — the gate blocks it.

## Verification

Against the live Actions API:

| Case | Result |
| --- | --- |
| 6.8.0 release commit | passes |
| 6.7.0 release commit | passes |
| commit with no release run | times out, publishes nothing |
| CI workflow renamed (404) | fails closed |

Decision logic, with stubbed API responses:

| Case | Result |
| --- | --- |
| release run failed | fails immediately, no 55-minute idle |
| release run cancelled | fails immediately |
| failure, then a successful re-run | passes |
| queued → in_progress → success | passes |
| run never finishes | times out, publishes nothing |

`actionlint` is clean on both workflows.

## Trade-off

The gate holds a runner while CI runs (CI jobs cap at 30 minutes; the gate gives up at 55). The alternative that avoids this is moving the publish job into `node.js.yml` with `needs: [build]` — simpler YAML and perfect provenance, but it requires updating the trusted publisher filename on npmjs.com from `publish.yml` to `node.js.yml` first, and releases fail until that is done. Happy to switch if you would rather make that change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated release workflows to prevent unrelated runs from cancelling each other.
  * Releases now wait for the corresponding continuous integration checks to complete successfully before publishing.
  * Reduced workflow permissions and limited publishing access to only what is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
