### PR TITLE
Fail fast on lint in a parallel job, and scope spellcheck to markdown

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,6 +41,39 @@ env:
   FALKORDB_VERSION: ${{ github.event.inputs.falkordb_image_tag || (github.event_name == 'schedule' && 'edge' || 'latest') }}
 
 jobs:
+  # Lint and compile on a runner of their own, with no FalkorDB container in
+  # sight, so a lint or type error is reported in roughly ten seconds instead
+  # of after three docker stacks have been pulled and started.
+  #
+  # This is deliberately a separate job rather than a reordering of `build`.
+  # Hoisting the install above the containers there looks free but is not: it
+  # currently runs while the cluster forms and absorbs most of that time, so
+  # `Wait for cluster to be fully ready` measures 4-10s on main (mean 7.8s over
+  # the last 8 build jobs). With the install hoisted it measured 21s on both
+  # matrix legs, taking the job from an ~88s mean to 103s - so every *passing*
+  # run pays for the fast failure. See #536.
+  lint:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        persist-credentials: false
+
+    # One version is enough here: this job checks the sources, not the runtime,
+    # and `build` still compiles on both matrix legs.
+    - name: Use Node.js 20.x
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 20.x
+        cache: 'npm'
+
+    - run: npm ci
+    - run: npm run lint
+    - run: npm run build --if-present
+
   build:
 
     runs-on: ubuntu-latest
@@ -209,7 +242,7 @@ jobs:
   # downgrade the caller's token.
   report-scheduled-failure:
     name: Report scheduled failure
-    needs: [build]
+    needs: [build, lint]
     # `cancelled` as well as `failure`: a job stopped by its own timeout, or one
     # that ran into GitHub's six hour ceiling, reports `cancelled`, and a nightly
     # that hangs is exactly the case this alert exists for.

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,9 +1,26 @@
 name: Spellcheck
+# Only markdown is spellchecked - spellcheck-settings.yml lists `*.md` and
+# `docs/*.md` as its sources - so a code-only change has nothing to check.
+# `**.md` rather than `**/*.md` because the latter does not match markdown at
+# the repository root, which is where README.md and RELEASE.md live. The
+# dictionary, the config and this workflow are listed too, so changing what
+# counts as a misspelling re-runs the check against the existing docs.
+#
+# Safe to filter here because Spellcheck is not a required status check. The
+# CI workflow deliberately has no such filter: a workflow skipped by path
+# filtering leaves its checks pending forever, and `build (20.x)` is required
+# on main, so a docs-only pull request could never be merged.
 on:
   push:
     branches: [main]
+    paths: &spellcheck-paths
+      - '**.md'
+      - '.github/wordlist.txt'
+      - '.github/spellcheck-settings.yml'
+      - '.github/workflows/spellcheck.yml'
   pull_request:
     branches: [main]
+    paths: *spellcheck-paths
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,20 +1,26 @@
 name: Spellcheck
-# Only markdown is spellchecked - spellcheck-settings.yml lists `*.md` and
-# `docs/*.md` as its sources - so a code-only change has nothing to check.
-# `**.md` rather than `**/*.md` because the latter does not match markdown at
-# the repository root, which is where README.md and RELEASE.md live. The
-# dictionary, the config and this workflow are listed too, so changing what
+# Only markdown is spellchecked, and only some of it: spellcheck-settings.yml
+# lists `*.md` and `docs/*.md` as its sources. These patterns mirror those two
+# exactly - `*` does not cross a `/`, so `*.md` is the repository root and
+# `docs/*.md` is that one directory - which keeps examples/README.md, which is
+# not a source, from starting a run that would check nothing. Keep the two
+# lists in step: a path here that is not a source wastes a run, and a source
+# missing from here stops being re-checked when it changes.
+#
+# The dictionary, the config and this workflow are listed too, so changing what
 # counts as a misspelling re-runs the check against the existing docs.
 #
-# Safe to filter here because Spellcheck is not a required status check. The
-# CI workflow deliberately has no such filter: a workflow skipped by path
-# filtering leaves its checks pending forever, and `build (20.x)` is required
-# on main, so a docs-only pull request could never be merged.
+# Safe to filter here because Spellcheck is not a required status check. CI
+# deliberately has no such filter: "If a workflow is skipped due to path
+# filtering, branch filtering or a commit message, then checks associated with
+# that workflow will remain in a 'Pending' state", and `build (20.x)` is
+# required on main, so a docs-only pull request could never be merged.
 on:
   push:
     branches: [main]
     paths: &spellcheck-paths
-      - '**.md'
+      - '*.md'
+      - 'docs/*.md'
       - '.github/wordlist.txt'
       - '.github/spellcheck-settings.yml'
       - '.github/workflows/spellcheck.yml'


### PR DESCRIPTION
Implements the goal of #536 — stop waiting on three FalkorDB stacks before a lint or compile error is reported — while keeping CI's wall clock where it is. Part of #534.

## The measurement that shaped this

#536 hoists the Node setup, `npm ci`, `npm run lint` and `npm run build` above the docker stacks in `build`, describing it as "a pure move, no behaviour change on a passing run". It is not. Those steps currently run **while the cluster forms** and absorb most of the formation time, so the later poll has little left to wait for:

| | `Wait for cluster to be fully ready` | job total |
| --- | --- | --- |
| `main` (install after the containers) | 4–10s, mean **7.8s** | mean **88s** |
| #536 (install before the containers) | **21s**, both matrix legs | **103s**, both legs |
| this PR | 9s / 10s | 92s / 83s |

Sample: the last 8 `build` jobs on `main` (runs 34223144334, 34219810281, 34218498590, 34216345363), and both legs of #536's run 34219011829.

Cluster formation is real work that happens either way. Today it is largely hidden behind the install; hoisting the install exposes it as dead wait, so every *passing* run pays roughly 15s more — the opposite of what #534 asks for. Both of #536's legs were slower than all 8 recent `main` jobs.

So the ordering in `build` is left exactly as it is, and the fast feedback is bought somewhere it costs nothing.

## What changed

**`node.js.yml`** — a new `lint` job that checks out, installs, lints and compiles on its own runner with no container in sight. It runs in parallel with `build`, so a lint or type error surfaces in **18s** (measured on this PR) instead of ~32s, and `build` keeps its ordering and its cluster wait. Single Node version on purpose: this job checks the sources, not the runtime, and `build` still compiles on both matrix legs.

`report-scheduled-failure` now lists `lint` in `needs` as well, so a nightly that fails on lint still raises the alert rather than passing silently.

**`spellcheck.yml`** — a `paths` filter, from #536. `spellcheck-settings.yml` sources only `*.md` and `docs/*.md`, so a code-only change has nothing to spellcheck. The filter lists those same two patterns rather than #536's `**.md`: `**.md` is every markdown file in the repository, which would have made an edit to `examples/README.md` — the one markdown file that is not a source — start a run that checked nothing. Mirroring the config means the workflow runs exactly when a file it can check has changed.

## Why filtering is safe here but not on CI

`Spellcheck` is not a required status check — `build (20.x)` is the only one:

```
$ gh api repos/FalkorDB/falkordb-ts/branches/main/protection --jq .required_status_checks.contexts
["build (20.x)"]
```

A workflow skipped by path filtering leaves its checks Pending forever, so putting a `paths` filter on CI would make any docs-only pull request unmergeable. #536 called this out correctly and I have kept its reasoning in the file so nobody re-derives it.

## Also carried over from #536's analysis

`paths-ignore` on CI (deadlocks docs-only PRs), `cache-dependency-path` (already the default for `cache: 'npm'`) and restricting lint to one matrix leg (parallel legs — saves nothing on wall clock) were all correctly rejected there, and remain rejected here.

## Validation

- `actionlint` clean on both workflows.
- The YAML alias resolves to an identical four-entry list on both triggers, confirmed by parsing the file. Anchors and aliases have been supported since the [2025-09-18 Actions changelog](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/); only merge keys (`<<:`) are not, and none are used. `spellcheck` ran and passed on this PR, which changes `spellcheck.yml` and so matches its own new filter.
- `npm run lint` and `npm run build` pass locally.
- `build`'s step order is unchanged — verified by parsing the workflow, not by eye.
- Full run green: `lint` 18s, `build (20.x)` 92s, `build (22.x)` 83s, `spellcheck` 15s.

## Follow-up worth a look, not done here

Teardown is a quiet 25s of the ~88s job (`Post Run docker-compose` × 3 = 12s + 11s + 2s) to stop containers on a runner that is about to be destroyed. Worth a separate issue.

Closes #536.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a dedicated Node.js 20 lint-and-build check to CI.
  * Scheduled failure reporting now waits for both build and lint checks.
  * Limited spellcheck workflow runs to changes in documentation, spelling configuration, word lists, and the spellcheck workflow itself.
  * Code-only changes no longer trigger spellcheck runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->